### PR TITLE
支持 github release 发布pdf

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
       
-      # 2. 安装 LaTeX 环境
+      # 2. 安装 LaTeX 环境和 Asymptote
       - name: 安装 LaTeX 环境
         run: |
           sudo apt-get update
@@ -34,17 +34,25 @@ jobs:
             texlive-latex-extra \
             texlive-fonts-recommended \
             texlive-fonts-extra \
-            texlive-lang-chinese
+            texlive-lang-chinese \
+            asymptote
       
       # 3. 赋予构建脚本执行权限
       - name: 设置脚本执行权限
-        run: chmod +x full-build.sh clear.sh
+        run: chmod +x full-build.sh clear.sh build-pic.sh
       
-      # 4. 执行构建脚本
-      - name: 执行构建
+      # 4. 构建图片文件
+      - name: 构建图片
+        run: |
+          echo "开始构建 Asymptote 图片..."
+          ./build-pic.sh
+          echo "图片构建完成"
+      
+      # 5. 执行 LaTeX 构建脚本
+      - name: 执行 LaTeX 构建
         run: ./full-build.sh
       
-      # 5. 验证 PDF 文件是否生成
+      # 6. 验证 PDF 文件是否生成
       - name: 验证构建产物
         run: |
           if [ ! -f "calculus-note.pdf" ]; then
@@ -54,7 +62,7 @@ jobs:
           echo "PDF 文件已成功生成"
           ls -lh calculus-note.pdf
       
-      # 6. 提取版本信息
+      # 7. 提取版本信息
       - name: 获取版本信息
         id: get_version
         run: |
@@ -66,7 +74,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "发布版本: $VERSION"
       
-      # 7. 创建 Release 并上传 PDF
+      # 8. 创建 Release 并上传 PDF
       - name: 创建 GitHub Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,97 @@
+name: 构建并发布 PDF
+
+on:
+  # 当推送标签时触发
+  push:
+    tags:
+      - 'v*'
+  # 支持手动触发
+  workflow_dispatch:
+
+# 配置权限
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-release:
+    name: 构建并发布微积分笔记
+    runs-on: ubuntu-latest
+    
+    steps:
+      # 1. 检出代码仓库
+      - name: 检出代码
+        uses: actions/checkout@v4
+      
+      # 2. 安装 LaTeX 环境
+      - name: 安装 LaTeX 环境
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-xetex \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-lang-chinese
+      
+      # 3. 赋予构建脚本执行权限
+      - name: 设置脚本执行权限
+        run: chmod +x full-build.sh clear.sh
+      
+      # 4. 执行构建脚本
+      - name: 执行构建
+        run: ./full-build.sh
+      
+      # 5. 验证 PDF 文件是否生成
+      - name: 验证构建产物
+        run: |
+          if [ ! -f "calculus-note.pdf" ]; then
+            echo "错误: PDF 文件未生成"
+            exit 1
+          fi
+          echo "PDF 文件已成功生成"
+          ls -lh calculus-note.pdf
+      
+      # 6. 提取版本信息
+      - name: 获取版本信息
+        id: get_version
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="dev-$(git rev-parse --short HEAD)"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "发布版本: $VERSION"
+      
+      # 7. 创建 Release 并上传 PDF
+      - name: 创建 GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: 微积分笔记 ${{ steps.get_version.outputs.version }}
+          body: |
+            ## 📚 微积分学教程笔记
+            
+            本次发布包含完整的微积分学习笔记 PDF 文档。
+            
+            ### 内容涵盖
+            - 极限论：数列极限、函数极限、连续性
+            - 微分学：导数、微分、偏导数、泰勒公式、微分中值定理
+            - 积分学：不定积分、定积分、重积分、曲线曲面积分、含参积分、瑕积分
+            - 级数理论：数项级数、函数项级数、傅里叶级数
+            
+            ### 下载
+            请下载下方的 `calculus-note.pdf` 文件。
+            
+            ---
+            构建时间: ${{ github.event.head_commit.timestamp }}
+            提交 SHA: ${{ github.sha }}
+          files: |
+            calculus-note.pdf
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# GitHub Actions 自动发布指南

本项目已配置 GitHub Actions 自动化工作流,可以自动构建 LaTeX 文档并发布到 GitHub Releases。

## 快速开始

### 发布新版本

只需创建并推送一个版本标签:

```bash
# 创建版本标签
git tag v1.0.0

# 推送到 GitHub
git push origin v1.0.0
```

GitHub Actions 会自动:
1. 构建 PDF 文档
2. 创建 GitHub Release
3. 上传 PDF 到 Release

### 手动触发构建

1. 访问仓库的 [Actions 页面](../../actions)
2. 选择 "构建并发布 PDF" 工作流
3. 点击 "Run workflow" 按钮

## 详细说明

- 工作流配置文件: `.github/workflows/build-and-release.yml`
- 完整使用说明: [.github/workflows/README.md](.github/workflows/README.md)

## 版本号规范

推荐使用语义化版本号:
- `v1.0.0` - 主版本.次版本.修订号
- `v1.0.0-beta` - 预发布版本

## 本地测试

在推送标签前建议本地测试:

```bash
chmod +x full-build.sh
./full-build.sh
```

## 获取已发布的 PDF

访问 [Releases 页面](../../releases) 下载最新版本的 PDF 文档。